### PR TITLE
Fix undefined sensor name in warning log

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-adt-pulse",
   "displayName": "Homebridge ADT Pulse",
-  "version": "3.4.19",
+  "version": "3.4.20",
   "description": "Homebridge security system platform for ADT Pulse",
   "main": "./build/index.js",
   "exports": "./build/index.js",

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1153,7 +1153,7 @@ export class ADTPulsePlatform implements ADTPulsePlatformPlugin {
 
         // If sensor was not found, it could be that the config was wrong.
         if (sensor === undefined) {
-          this.#log.warn(`Attempted to add or update ${chalk.underline(name)} (adtName: ${adtName}, adtZone: ${adtZone}, adtType: ${adtType}) accessory that does not exist on the portal.`);
+          this.#log.warn(`Attempted to add or update ${chalk.underline(name ?? adtName)} (adtName: ${adtName}, adtZone: ${adtZone}, adtType: ${adtType}) accessory that does not exist on the portal.`);
 
           continue;
         }


### PR DESCRIPTION
## Summary
- Apply the `name ?? adtName` fallback pattern to the remaining log line in `unifyDevices()` at `platform.ts:1156` that was missing it
- This is the same fix from PR #154 applied to one additional instance where `configuredSensor.name` could display as `undefined` when the optional `name` field is omitted from sensor config
- Bump version to `3.4.20`

## Test plan
- [x] Build passes (ESLint, TypeScript, Vite)
- [x] Verify log output shows `adtName` instead of `undefined` when sensor `name` is not configured
